### PR TITLE
Fix WebRTC audio track handling

### DIFF
--- a/api/webrtc.py
+++ b/api/webrtc.py
@@ -85,7 +85,8 @@ async def offer(request: Request):
         # 只处理音频轨道
         if track.kind != "audio":
             return
-        async for frame in track:
+        while True:
+            frame = await track.recv()
             # 将音频帧转换为原始 PCM 数据
             pcm = frame.to_ndarray().tobytes()
             frame_buffer += pcm


### PR DESCRIPTION
## Summary
- fix remote track iteration by using `await track.recv()`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688348089074832e9c5ac6b4126f4fd4