### PR TITLE
Read API key from env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,12 @@
 
 This example shows a simple ChatGPT-like voice conversation using WebSocket.
 
+Set the `BIGMODEL_API_KEY` environment variable to your Zhipu API key before running.
+
 Run the API server:
 
 ```bash
+export BIGMODEL_API_KEY=<your-api-key>
 python main.py
 ```
 

--- a/services/llm_service.py
+++ b/services/llm_service.py
@@ -1,9 +1,9 @@
 """调用智谱 AI 聊天接口的封装函数。"""
 
 from zhipuai import ZhipuAI
+import os
 
-BIGMODEL_API_KEY = "fe28433d565d40a5a1806ab43719e504.HHwmOUiDA4XPCDkk"
-client = ZhipuAI(api_key=BIGMODEL_API_KEY)
+client = ZhipuAI(api_key=os.getenv("BIGMODEL_API_KEY"))
 
 
 def format_messages(user_text: str):


### PR DESCRIPTION
## Summary
- fetch the Zhipu API key via `os.getenv`
- note the environment variable in the README

## Testing
- `python -m py_compile services/llm_service.py`
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_68834d999cb4832eb4814d07f65ed45a