### PR TITLE
Add data channel for transcript exchange

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -56,28 +56,24 @@
         let ttsChannel
         // 本地音频流
         let localStream
+        // 远端语音播放
+        let remoteAudio
 
         /**
-         * 播放机器人返回的音频数据
-         * @param {string} hex - 16进制字符串音频数据
+         * 播放远端语音轨道
+         * @param {MediaStreamTrack} track - 远端音频轨道
          */
-        function playAudio(hex) {
-          // 将16进制字符串转为Uint8Array
-          const bytes = new Uint8Array(hex.match(/.{1,2}/g).map(b => parseInt(b, 16)))
-          // 创建音频Blob对象
-          const blob = new Blob([bytes], { type: 'audio/wav' })
-          // 创建音频URL
-          const url = URL.createObjectURL(blob)
-          // 创建音频对象并播放
-          const audio = new Audio(url)
-          audio.onended = () => {
-            // 播放结束后，1秒后进入“等待用户说话”状态
+        function playRemoteTrack(track) {
+          const stream = new MediaStream([track])
+          remoteAudio = new Audio()
+          remoteAudio.srcObject = stream
+          remoteAudio.onended = () => {
             setTimeout(() => {
               listening.value = true
               userText.value = ''
             }, 1000)
           }
-          audio.play()
+          remoteAudio.play()
         }
 
         /**
@@ -132,9 +128,12 @@
               } else if (msg.type === 'text') {
                 // 机器人文本回复
                 typeReply(msg.data)
-              } else if (msg.type === 'audio') {
-                // 机器人语音回复
-                playAudio(msg.data)
+              }
+            }
+
+            pc.ontrack = (ev) => {
+              if (ev.track.kind === 'audio') {
+                playRemoteTrack(ev.track)
               }
             }
 


### PR DESCRIPTION
## Summary
- send ASR transcript and LLM reply via a WebRTC datachannel
- play synthesized audio from the remote track in the front-end

## Testing
- `python -m py_compile api/webrtc.py services/asr_service.py services/llm_service.py services/tts_service.py api/control_ws.py api/routes.py main.py`

------
https://chatgpt.com/codex/tasks/task_e_68834d9debb0832e95d1da9375fc7a64