### PR TITLE
Adjust caption speed to better match speech

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -84,7 +84,7 @@
           reply.value = []
           typing.value = true
           let i = 0
-          // 每50ms显示一个字符
+          // 每150ms显示一个字符，速度与语音播放接近
           const timer = setInterval(() => {
             reply.value.push({ id: reply.value.length, text: text[i] })
             i++
@@ -94,7 +94,7 @@
               // 回复结束后加入历史
               history.value.push({ role: 'bot', text })
             }
-          }, 50)
+          }, 150)
         }
 
         /**


### PR DESCRIPTION
## Summary
- update `typeReply` function in `frontend/index.html` to display one character every 150 ms for subtitles, matching speech pace

## Testing
- `pytest -q`
- `python -m py_compile main.py api/*.py services/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68836eb5e440832eb1e46ac87311c14b