### PR TITLE
Fix audio frame layout in WebRTC TTS stream

### DIFF
--- a/api/webrtc.py
+++ b/api/webrtc.py
@@ -38,7 +38,7 @@ class TTSTrack(MediaStreamTrack):
             if self.stop_event.is_set():
                 break
             array = np.frombuffer(chunk, dtype=np.int16)
-            array = array.reshape(-1, 1)
+            array = array.reshape(1, -1)
             frame = av.AudioFrame.from_ndarray(array, layout="mono")
             await self.queue.put(frame)
         await self.queue.put(None)


### PR DESCRIPTION
## Summary
- fix shape of numpy array before creating `AudioFrame`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688371098b9c832ea7de4f9a4fecaa42