### PR TITLE
Fix audio conversion for ASR

### DIFF
--- a/api/webrtc.py
+++ b/api/webrtc.py
@@ -102,7 +102,12 @@ async def offer(request: Request):
             except MediaStreamError:
                 break
             # 将音频帧转换为原始 PCM 数据，并重采样到 ASR 需要的采样率
-            pcm = frame.to_ndarray().tobytes()
+            array = frame.to_ndarray()
+            if array.ndim > 1:
+                array = array.mean(axis=0)
+            if array.dtype != np.int16:
+                array = array.astype(np.int16)
+            pcm = array.tobytes()
             if frame.sample_rate != SAMPLE_RATE:
                 pcm, _ = audioop.ratecv(pcm, 2, 1, frame.sample_rate, SAMPLE_RATE, None)
             frame_buffer += pcm


### PR DESCRIPTION
## Summary
- ensure incoming frames are converted to mono int16 before resampling

## Testing
- `python -m py_compile api/webrtc.py services/asr_service.py services/tts_service.py api/routes.py main.py`

------
https://chatgpt.com/codex/tasks/task_e_68837fbf1148832e95345ac397a2ffd3