### PR TITLE
Implement voice pause detection and one-way video

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,5 +27,9 @@ export BIGMODEL_API_KEY=<your-api-key>
 python main.py
 ```
 
-Open `http://localhost:8000/` in the browser and allow microphone access.
-Click the **Video** button to establish a WebRTC connection and stream your webcam to the server. You can switch the video on or off without affecting the voice conversation.
+Open `http://localhost:8000/` in the browser and allow microphone access. The
+microphone starts automatically and the server listens for speech pauses before
+running ASR, LLM and TTS.
+
+Click the **Video** button if you want to stream your webcam. Video is received
+only; the server does not echo the stream back to the browser.

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1,4 +1,4 @@
-import { createApp, ref, nextTick } from 'https://unpkg.com/vue@3/dist/vue.esm-browser.js'
+import { createApp, ref, nextTick, onMounted } from 'https://unpkg.com/vue@3/dist/vue.esm-browser.js'
 
 createApp({
   setup() {
@@ -190,6 +190,10 @@ createApp({
         await startVideo()
       }
     }
+
+    onMounted(() => {
+      startCall()
+    })
 
     return {
       reply, history, userText, recording, listening, typing, error,

--- a/services/buffers.py
+++ b/services/buffers.py
@@ -1,0 +1,9 @@
+"""Shared audio and video buffers used by WebSocket and WebRTC handlers."""
+
+# Raw PCM data collected from the browser. This is cleared after each speech
+# segment finishes processing.
+audio_buffer = bytearray()
+
+# List of received video frames from the WebRTC track. Frames are stored until a
+# speech pause is detected, then the list is cleared.
+video_frames = []


### PR DESCRIPTION
## Summary
- only receive WebRTC video tracks
- implement VAD-based speech segmentation over WebSocket audio
- expose shared audio/video buffers
- auto start microphone when the page loads
- document new behaviour

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6884377b7a98832ea78e8dd300bdecad