### PR TITLE
Fix Edge TTS output for websocket playback

### DIFF
--- a/services/tts_service.py
+++ b/services/tts_service.py
@@ -7,16 +7,23 @@ import edge_tts
 
 VOICE = "zh-CN-XiaoxiaoNeural"
 TTS_DIR = "tts_recordings"
-SAMPLE_RATE = 48000
+
+# Edge TTS 默认返回 MP3 数据，不便于直接重采样。我们改为输出原始
+# 16-bit PCM，采样率为 24kHz，随后在 WebSocket 中再升采样到客户端
+# 需要的 48kHz。
+SAMPLE_RATE = 24000
+OUTPUT_FORMAT = "raw-24khz-16bit-mono-pcm"
 
 
 async def synthesize(text: str) -> bytes:
     """将文本一次性合成为语音并返回 WAV 数据，并保存文件。"""
     communicator = edge_tts.Communicate(
-        text=text, voice=VOICE
+        text=text,
+        voice=VOICE,
+        output_format=OUTPUT_FORMAT,
     )
     os.makedirs(TTS_DIR, exist_ok=True)
-    output_path = f"{TTS_DIR}/{uuid.uuid4()}.mp3"
+    output_path = f"{TTS_DIR}/{uuid.uuid4()}.wav"
     audio_bytes = b""
     async for chunk in communicator.stream():
         if chunk["type"] == "audio":
@@ -29,10 +36,12 @@ async def synthesize(text: str) -> bytes:
 async def synthesize_stream(text: str):
     """异步生成语音数据块，用于流式播放，同时保存文件。"""
     communicator = edge_tts.Communicate(
-        text=text, voice=VOICE
+        text=text,
+        voice=VOICE,
+        output_format=OUTPUT_FORMAT,
     )
     os.makedirs(TTS_DIR, exist_ok=True)
-    output_path = f"{TTS_DIR}/{uuid.uuid4()}.mp3"
+    output_path = f"{TTS_DIR}/{uuid.uuid4()}.wav"
     with open(output_path, "wb") as wf:
         async for chunk in communicator.stream():
             if chunk["type"] == "audio":


### PR DESCRIPTION
## Summary
- configure `tts_service` to emit raw PCM instead of MP3
- save TTS output as `.wav` and specify the output format

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `black services/tts_service.py`

------
https://chatgpt.com/codex/tasks/task_e_68844e01eb10832ea8f0f873e8dbdd48