### PR TITLE
Prevent TTS feedback loop

### DIFF
--- a/api/websocket.py
+++ b/api/websocket.py
@@ -89,6 +89,8 @@ async def audio_endpoint(websocket: WebSocket):
 
                                 listening = False
                                 await stream_tts(websocket, reply_text)
+                                await websocket.send_text(json.dumps({"type": "end"}))
+                                vad_buffer.clear()
                                 listening = True
 
                         silence = 0
@@ -115,6 +117,8 @@ async def audio_endpoint(websocket: WebSocket):
 
                             listening = False
                             await stream_tts(websocket, reply_text)
+                            await websocket.send_text(json.dumps({"type": "end"}))
+                            vad_buffer.clear()
                             listening = True
 
                 elif payload.get("type") in {"close", "stop"}:

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -138,7 +138,7 @@ createApp({
       workletNode = new AudioWorkletNode(audioCtx, 'pcm-processor', { numberOfInputs: 1, numberOfOutputs: 0 })
       workletNode.port.onmessage = (ev) => {
         // 这里的 ev.data 是你在 processor 里 postMessage 上来的 PCM Int16/Float32 等
-        if (ws && ws.readyState === WebSocket.OPEN) {
+        if (ws && ws.readyState === WebSocket.OPEN && listening.value) {
           // 注意：如果你传来的是 Float32Array，需要转换成 ArrayBuffer/Int16 再发
           ws.send(ev.data.buffer || ev.data)
         }


### PR DESCRIPTION
## Summary
- ensure client resumes recording only after TTS ends
- gate microphone frames on `listening` state on the client
- send an `end` message after TTS to reset the listening state

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688481c3b4cc832e9b188e7fda240f92