### PR TITLE
Enhance subtitle and chat separation

### DIFF
--- a/api/websocket.py
+++ b/api/websocket.py
@@ -106,6 +106,17 @@ async def audio_endpoint(websocket: WebSocket):
                     audio_buffer.clear()
                     vad_buffer.clear()
                     video_frames.clear()
+                elif payload.get("type") == "text":
+                    text = payload.get("data", "")
+                    if text.strip():
+                        listening = False
+                        vad_buffer.clear()
+                        audio_buffer.clear()
+                        video_frames.clear()
+
+                        llm_reply = await full_reply(text)
+                        await websocket.send_text(json.dumps({"type": "llm_reply", "data": llm_reply}))
+                        await stream_tts(websocket, llm_reply)
 
     except WebSocketDisconnect:
         print("WebSocket disconnected")

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -32,6 +32,32 @@
             <line x1="1" y1="1" x2="23" y2="23"></line>
           </svg>
         </button>
+        <!-- TTS 音量控制 -->
+        <button class="icon-btn" @click="toggleTTS"
+          :aria-label="lang==='zh' ? (ttsMuted ? '取消静音' : '静音') : (ttsMuted ? 'Unmute' : 'Mute')"
+          :title="lang==='zh' ? (ttsMuted ? '取消静音' : '静音') : (ttsMuted ? 'Unmute' : 'Mute')">
+          <svg v-if="!ttsMuted" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5" />
+            <path d="M15.54 8.46a5 5 0 0 1 0 7.07" />
+            <path d="M19.07 4.93a11 11 0 0 1 0 15.57" />
+          </svg>
+          <svg v-else width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5" />
+            <line x1="23" y1="9" x2="17" y2="15" />
+            <line x1="17" y1="9" x2="23" y2="15" />
+          </svg>
+        </button>
+        <!-- 对话开关 -->
+        <button class="icon-btn" @click="toggleChat"
+          :aria-label="lang==='zh' ? (showChat ? '隐藏对话' : '显示对话') : (showChat ? 'Hide Chat' : 'Show Chat')"
+          :title="lang==='zh' ? (showChat ? '隐藏对话' : '显示对话') : (showChat ? 'Hide Chat' : 'Show Chat')">
+          <svg v-if="showChat" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
+          </svg>
+          <svg v-else width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M4 4h16v12H5.17L4 17.17V4z" />
+          </svg>
+        </button>
         <!-- 语言切换 -->
         <select v-model="lang" class="lang-selector" title="Language">
           <option value="zh">中文</option>
@@ -44,7 +70,11 @@
       <div class="video-box" v-if="videoEnabled">
         <video ref="localVideo" class="local-video" autoplay muted playsinline></video>
       </div>
-      <div v-if="showSubtitles" class="history subtitles" ref="historyEl">
+      <div v-if="showSubtitles" class="subtitles">
+        <span>{{ subtitle }}</span>
+        <span class="cursor" v-if="subtitleTyping">▋</span>
+      </div>
+      <div v-if="showChat" class="history chat-history" ref="historyEl">
         <div v-for="(msg, idx) in history" :key="idx" :class="['message', msg.role]">
           <template v-if="msg.role === 'bot' && Array.isArray(msg.tokens)">
             <span v-html="renderMarkdown(tokensToText(msg.tokens))"></span>
@@ -58,6 +88,7 @@
           </template>
         </div>
       </div>
+      <div v-else class="document-view" v-html="renderMarkdown(lastBotText)"></div>
     </div>
 
     <form class="chat-input-bar" @submit.prevent="onSendText">

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -5,6 +5,7 @@ html {
   padding: 0;
   background: #fafbfc;
   box-sizing: border-box;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif;
 }
 
 #app {
@@ -22,6 +23,7 @@ html {
   justify-content: space-between;
   padding: 0.7em 2em 0.2em 2em;
   background: #fff;
+  box-shadow: 0 2px 6px #0001;
 }
 
 .header-bar .title {
@@ -69,7 +71,7 @@ html {
   background: #111;
 }
 
-.history.subtitles {
+.subtitles {
   background: rgba(30, 30, 30, 0.85);
   color: #fff;
   padding: 1em 2em;
@@ -78,7 +80,7 @@ html {
   max-height: 18vh;
   min-height: 2.5em;
   overflow-y: auto;
-  font-size: 1.2em;
+  font-size: 1.5em; /* larger subtitles */
   text-align: center;
   margin: 1.5em auto 0.5em auto;
   box-shadow: 0 2px 8px #0002;
@@ -175,6 +177,17 @@ html {
   display: none;
 }
 
+.document-view {
+  background: #fff;
+  color: #333;
+  max-width: 80vw;
+  padding: 1em 1.5em;
+  border-radius: 12px;
+  box-shadow: 0 2px 8px #0002;
+  margin: 1em auto;
+  overflow-y: auto;
+}
+
 @media (max-width: 600px) {
   .header-bar {
     padding: 0.5em 0.5em 0.2em 0.6em;
@@ -187,7 +200,7 @@ html {
     max-width: 98vw;
   }
 
-  .history.subtitles {
+  .subtitles {
     max-width: 96vw;
     font-size: 1em;
   }


### PR DESCRIPTION
## Summary
- separate chat history from subtitle overlay
- allow toggling chat visibility
- display latest subtitle with typewriter effect
- render chat document view when chat is hidden

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6884a1506ee0832eb8e07bd25f75d763