### PR TITLE
Refactor endpoints to use local buffers

### DIFF
--- a/api/rtc.py
+++ b/api/rtc.py
@@ -2,7 +2,6 @@ from fastapi import APIRouter, Request
 from aiortc import RTCPeerConnection, RTCSessionDescription
 from aiortc.contrib.media import MediaRelay
 import asyncio
-from services.buffers import video_frames
 
 router = APIRouter(prefix="/rtc")
 relay = MediaRelay()
@@ -15,6 +14,7 @@ async def offer(request: Request):
 
     pc = RTCPeerConnection()
     pcs.add(pc)
+    video_frames = []
 
     @pc.on("connectionstatechange")
     async def on_state_change():

--- a/api/websocket.py
+++ b/api/websocket.py
@@ -10,7 +10,6 @@ from fastapi import APIRouter, WebSocket, WebSocketDisconnect
 from services.asr_service import transcribe
 from services.llm_service import full_reply
 from services.tts_service import synthesize_stream, DEFAULT_VOICE
-from services.buffers import audio_buffer, video_frames
 
 router = APIRouter(prefix="/ws")
 
@@ -48,6 +47,8 @@ async def audio_endpoint(websocket: WebSocket):
     await websocket.accept()
 
     vad_buffer = bytearray()
+    audio_buffer = bytearray()
+    video_frames = []
     silence = 0
     listening = True
     voice = DEFAULT_VOICE

--- a/services/buffers.py
+++ b/services/buffers.py
@@ -1,9 +1,0 @@
-"""Shared audio and video buffers used by WebSocket and WebRTC handlers."""
-
-# Raw PCM data collected from the browser. This is cleared after each speech
-# segment finishes processing.
-audio_buffer = bytearray()
-
-# List of received video frames from the WebRTC track. Frames are stored until a
-# speech pause is detected, then the list is cleared.
-video_frames = []


### PR DESCRIPTION
## Summary
- keep audio and video buffers scoped to individual WebSocket/RTC sessions
- remove unused shared buffer module

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6884cb8f7a88832e88789a2f8e4a0a5b