### PR TITLE
Fix MediaSource endOfStream error

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -90,9 +90,15 @@ createApp({
       })
     }
     function finalizeMediaSource() {
-      if (mediaSource && mediaSource.readyState === "open" && !listening.value) {
-        try { mediaSource.endOfStream() } catch (e) { }
+      if (!mediaSource || mediaSource.readyState !== "open" || listening.value)
+        return
+      if (sourceBuffer && (sourceBuffer.updating || mediaQueue.length > 0)) {
+        sourceBuffer.addEventListener('updateend', finalizeMediaSource, {
+          once: true
+        })
+        return
       }
+      try { mediaSource.endOfStream() } catch (e) { }
     }
     function appendNextChunk() {
       if (!sourceBuffer || sourceBuffer.updating) return


### PR DESCRIPTION
## Summary
- handle pending updates when calling `MediaSource.endOfStream`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68857cd0a4cc832e90f46859b6eae4db