### PR TITLE
Add voice selector and markdown rendering

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -37,6 +37,12 @@
           <option value="zh">中文</option>
           <option value="en">English</option>
         </select>
+        <!-- 语音角色选择 -->
+        <select v-model="voice" class="voice-selector" @change="onVoiceChange" :title="lang==='zh' ? '语音角色' : 'Voice'">
+          <option v-for="v in voices" :key="v.ShortName" :value="v.ShortName">
+            {{ v.FriendlyName || v.ShortName }}
+          </option>
+        </select>
       </div>
     </div>
 
@@ -46,13 +52,8 @@
       </div>
 
       <div class="history article" ref="historyEl">
-        <div v-for="(msg, idx) in history" :key="idx" :class="['message', msg.role]">
-          <template v-if="msg.role === 'bot'">
-            {{ msg.text }}
-          </template>
-          <template v-else>
-            {{ msg.text }}
-          </template>
+        <div v-for="(msg, idx) in history" :key="idx" :class="['message', msg.role, { playing: idx === speakingIndex }]">
+          <div v-html="marked.parse(msg.text)"></div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- render chat history using Markdown
- add voice selector next to language toggle
- handle voice change via `/api/voices`

## Testing
- `python -m py_compile main.py api/routes.py services/*.py`

------
https://chatgpt.com/codex/tasks/task_e_68858ca6c480832e997c2462ace01eb9