### PR TITLE
Fix global marked usage in Vue app

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1,5 +1,8 @@
 import { createApp, ref, nextTick, onMounted } from 'https://unpkg.com/vue@3/dist/vue.esm-browser.js'
 
+// marked is loaded globally via a script tag in index.html
+const { marked } = window
+
 class AsyncQueue {
   constructor() {
     this.queue = [];
@@ -329,7 +332,8 @@ createApp({
       lang, userInput, history, recording, listening, typing, error,
       toggleMic, toggleTTS, onSendText, onVoiceChange,
       historyEl, ttsMuted, localVideo, remoteVideo, videoEnabled, toggleVideo,
-      voices, voice, speakingIndex
+      voices, voice, speakingIndex,
+      marked
     }
   }
 }).mount('#app')


### PR DESCRIPTION
## Summary
- expose `marked` in `app.js` so Vue templates can access it

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68858dc66528832eb5f384546d81b0f8