### PR TITLE
Improve mobile layout

### DIFF
--- a/frontend/style.css
+++ b/frontend/style.css
@@ -14,6 +14,7 @@ html {
   flex-direction: column;
   align-items: center;
   justify-content: flex-start;
+  padding-bottom: 4.5em;
 }
 
 .header-bar {
@@ -87,9 +88,15 @@ html {
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 100vw;
+  position: fixed;
+  bottom: 0;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 100%;
   max-width: 700px;
-  margin: 0 auto 1.8em auto;
+  padding: 0.5em 0;
+  background: #fff;
+  box-shadow: 0 -2px 6px #0001;
   gap: 0.1em;
 }
 
@@ -169,13 +176,16 @@ html {
 }
 
 .history {
-  max-height: 62vh;
+  flex: 1;
   overflow-y: auto;
   margin: 1em 0;
   background: #fafbfc;
   border-radius: 12px;
   padding: 1em;
   font-size: 1.08em;
+  width: 100%;
+  max-width: 75vw;
+  box-sizing: border-box;
 }
 
 .history.hidden {
@@ -183,8 +193,16 @@ html {
 }
 
 @media (max-width: 600px) {
+  body {
+    font-size: 1.2em;
+  }
+
   .header-bar {
     padding: 0.5em 0.5em 0.2em 0.6em;
+  }
+
+  .chat-input {
+    font-size: 1.1em;
   }
 
   .main-pane,


### PR DESCRIPTION
## Summary
- keep overall layout but enhance mobile experience
- fix input bar at bottom of screen
- let history scroll and fill available space
- enlarge fonts for small screens

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688594466978832e9451f3c30b449382