### PR TITLE
Refactor frontend UI with Vue3 CDN and Naive UI

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1,4 +1,4 @@
-import { createApp, ref, nextTick, onMounted } from 'https://unpkg.com/vue@3/dist/vue.esm-browser.js'
+const { createApp, ref, nextTick, onMounted, computed } = Vue
 
 // marked is loaded globally via a script tag in index.html
 const { marked } = window
@@ -43,6 +43,16 @@ createApp({
     const videoEnabled = ref(false)
     const voices = ref([])
     const voice = ref('zh-CN-XiaoxiaoNeural')
+    const langOptions = [
+      { label: '中文', value: 'zh' },
+      { label: 'English', value: 'en' }
+    ]
+    const voiceOptions = computed(() =>
+      voices.value.map(v => ({
+        label: v.FriendlyName || v.ShortName,
+        value: v.ShortName
+      }))
+    )
 
     const historyEl = ref(null)
     const localVideo = ref(null)
@@ -357,7 +367,8 @@ createApp({
       toggleMic, toggleTTS, onSendText, onVoiceChange,
       historyEl, ttsMuted, localVideo, remoteVideo, videoEnabled, toggleVideo,
       voices, voice, speakingIndex,
+      langOptions, voiceOptions,
       marked
     }
   }
-}).mount('#app')
+}).use(naive).mount('#app')

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -6,106 +6,71 @@
   <title>语音助手 / Voice Assistant</title>
   <link rel="stylesheet" href="/static/style.css" />
   <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
-  <script type="module" src="https://unpkg.com/vue@3/dist/vue.esm-browser.js"></script>
-  <script type="module" src="/static/app.js"></script>
+  <script src="https://unpkg.com/vue@3"></script>
+  <script src="https://unpkg.com/naive-ui"></script>
+  <script src="https://unpkg.com/@vicons/ionicons5"></script>
+  <script src="/static/app.js"></script>
 </head>
 
 <body>
   <div id="app">
-    <div class="header-bar">
-      <span class="title">{{ lang === 'zh' ? '语音助手' : 'Voice Assistant' }}</span>
-      <div style="display: flex; align-items: center;">
-        <!-- TTS 音量控制 -->
-        <button class="icon-btn" @click="toggleTTS"
-          :aria-label="lang==='zh' ? (ttsMuted ? '取消静音' : '静音') : (ttsMuted ? 'Unmute' : 'Mute')"
-          :title="lang==='zh' ? (ttsMuted ? '取消静音' : '静音') : (ttsMuted ? 'Unmute' : 'Mute')">
-          <svg v-if="!ttsMuted" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor"
-            stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-            <polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5" />
-            <path d="M15.54 8.46a5 5 0 0 1 0 7.07" />
-            <path d="M19.07 4.93a11 11 0 0 1 0 15.57" />
-          </svg>
-          <svg v-else width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
-            stroke-linecap="round" stroke-linejoin="round">
-            <polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5" />
-            <line x1="23" y1="9" x2="17" y2="15" />
-            <line x1="17" y1="9" x2="23" y2="15" />
-          </svg>
-        </button>
-        <!-- 语言切换 -->
-        <select v-model="lang" class="lang-selector" title="Language">
-          <option value="zh">中文</option>
-          <option value="en">English</option>
-        </select>
-        <!-- 语音角色选择 -->
-        <select v-model="voice" class="voice-selector" @change="onVoiceChange" :title="lang==='zh' ? '语音角色' : 'Voice'">
-          <option v-for="v in voices" :key="v.ShortName" :value="v.ShortName">
-            {{ v.FriendlyName || v.ShortName }}
-          </option>
-        </select>
-      </div>
-    </div>
-
-    <div class="main-pane" :class="{ 'video-mode': videoEnabled }">
-      <div class="video-box" v-if="videoEnabled">
-        <video ref="localVideo" class="local-video" autoplay muted playsinline></video>
-      </div>
-
-      <div class="history article" ref="historyEl">
-        <div v-for="(msg, idx) in history" :key="idx"
-          :class="['message', msg.role, { playing: idx === speakingIndex }]">
-          <div v-html="marked.parse(msg.text)"></div>
+    <n-layout>
+      <n-layout-header class="header-bar">
+        <span class="title">{{ lang === 'zh' ? '语音助手' : 'Voice Assistant' }}</span>
+        <div style="display: flex; align-items: center;">
+          <n-button quaternary circle class="icon-btn" @click="toggleTTS"
+            :aria-label="lang==='zh' ? (ttsMuted ? '取消静音' : '静音') : (ttsMuted ? 'Unmute' : 'Mute')"
+            :title="lang==='zh' ? (ttsMuted ? '取消静音' : '静音') : (ttsMuted ? 'Unmute' : 'Mute')">
+            <template #icon>
+              <n-icon v-if="!ttsMuted"><VolumeHighOutline /></n-icon>
+              <n-icon v-else><VolumeMuteOutline /></n-icon>
+            </template>
+          </n-button>
+          <n-select v-model:value="lang" class="lang-selector" :options="langOptions" />
+          <n-select v-model:value="voice" class="voice-selector" @update:value="onVoiceChange" :options="voiceOptions" />
         </div>
-      </div>
-    </div>
+      </n-layout-header>
 
-    <form class="chat-input-bar" @submit.prevent="onSendText">
-      <input class="chat-input" v-model="userInput" :placeholder="lang==='zh' ? '请输入你的问题...' : 'Type your question...'"
-        :aria-label="lang==='zh' ? '输入' : 'Input'" autocomplete="off" @keydown.enter.exact.prevent="onSendText" />
-      <button type="submit" class="icon-btn send-btn" :aria-label="lang==='zh' ? '发送' : 'Send'"
-        :title="lang==='zh' ? '发送' : 'Send'">
-        <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
-          stroke-linecap="round" stroke-linejoin="round">
-          <path d="M22 2 11 13"></path>
-          <path d="m22 2-7 20-4-9-9-4Z"></path>
-        </svg>
-      </button>
-      <button type="button" class="icon-btn" @click="toggleMic"
-        :aria-label="lang==='zh' ? (recording ? '停止语音' : '语音输入') : (recording ? 'Stop Voice' : 'Voice Input')"
-        :title="lang==='zh' ? (recording ? '停止语音' : '语音输入') : (recording ? 'Stop Voice' : 'Voice Input')">
-        <svg v-if="!recording" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor"
-          stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-          <rect x="9" y="2" width="6" height="11" rx="3"></rect>
-          <path d="M19 10v2a7 7 0 0 1-14 0v-2"></path>
-          <line x1="12" y1="19" x2="12" y2="22"></line>
-          <line x1="8" y1="22" x2="16" y2="22"></line>
-        </svg>
-        <svg v-else width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
-          stroke-linecap="round" stroke-linejoin="round">
-          <rect x="9" y="2" width="6" height="11" rx="3"></rect>
-          <path d="M19 10v2a7 7 0 0 1-14 0v-2"></path>
-          <line x1="12" y1="19" x2="12" y2="22"></line>
-          <line x1="8" y1="22" x2="16" y2="22"></line>
-          <line x1="2" y1="2" x2="22" y2="22"></line>
-        </svg>
-      </button>
-      <button type="button" class="icon-btn" @click="toggleVideo"
-        :aria-label="lang==='zh' ? (videoEnabled ? '关闭视频' : '开启视频') : (videoEnabled ? 'Stop Video' : 'Start Video')"
-        :title="lang==='zh' ? (videoEnabled ? '关闭视频' : '开启视频') : (videoEnabled ? 'Stop Video' : 'Start Video')">
-        <svg v-if="!videoEnabled" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor"
-          stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-          <rect width="15" height="11" x="2" y="7" rx="2" ry="2" />
-          <path d="M17 7l5 5-5 5V7z" />
-        </svg>
-        <svg v-else width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
-          stroke-linecap="round" stroke-linejoin="round">
-          <rect width="15" height="11" x="2" y="7" rx="2" ry="2" />
-          <path d="M17 7l5 5-5 5V7z" />
-          <line x1="1" y1="1" x2="23" y2="23" />
-        </svg>
-      </button>
-    </form>
-    <div v-if="error" class="error">⚠️ {{ error }}</div>
+      <n-layout-content class="main-pane" :class="{ 'video-mode': videoEnabled }">
+        <div class="video-box" v-if="videoEnabled">
+          <video ref="localVideo" class="local-video" autoplay muted playsinline></video>
+        </div>
+
+        <div class="history article" ref="historyEl">
+          <n-card v-for="(msg, idx) in history" :key="idx"
+            :class="['message', msg.role, { playing: idx === speakingIndex }]">
+            <div v-html="marked.parse(msg.text)"></div>
+          </n-card>
+        </div>
+      </n-layout-content>
+
+      <n-layout-footer class="chat-input-bar">
+        <n-input class="chat-input" v-model:value="userInput"
+          :placeholder="lang==='zh' ? '请输入你的问题...' : 'Type your question...'"
+          :aria-label="lang==='zh' ? '输入' : 'Input'" @keydown.enter.exact.prevent="onSendText" />
+        <n-button quaternary circle class="send-btn icon-btn" @click="onSendText"
+          :aria-label="lang==='zh' ? '发送' : 'Send'" :title="lang==='zh' ? '发送' : 'Send'">
+          <template #icon><n-icon><SendOutline /></n-icon></template>
+        </n-button>
+        <n-button quaternary circle class="icon-btn" @click="toggleMic"
+          :aria-label="lang==='zh' ? (recording ? '停止语音' : '语音输入') : (recording ? 'Stop Voice' : 'Voice Input')"
+          :title="lang==='zh' ? (recording ? '停止语音' : '语音输入') : (recording ? 'Stop Voice' : 'Voice Input')">
+          <template #icon>
+            <n-icon v-if="!recording"><MicOutline /></n-icon>
+            <n-icon v-else><StopCircleOutline /></n-icon>
+          </template>
+        </n-button>
+        <n-button quaternary circle class="icon-btn" @click="toggleVideo"
+          :aria-label="lang==='zh' ? (videoEnabled ? '关闭视频' : '开启视频') : (videoEnabled ? 'Stop Video' : 'Start Video')"
+          :title="lang==='zh' ? (videoEnabled ? '关闭视频' : '开启视频') : (videoEnabled ? 'Stop Video' : 'Start Video')">
+          <template #icon>
+            <n-icon v-if="!videoEnabled"><VideocamOutline /></n-icon>
+            <n-icon v-else><VideocamOffOutline /></n-icon>
+          </template>
+        </n-button>
+      </n-layout-footer>
+    </n-layout>
+    <div v-if="error" class="error">Error: {{ error }}</div>
   </div>
 </body>
 


### PR DESCRIPTION
## Summary
- migrate page to use Vue3 global build
- integrate Naive UI layout and controls
- use ionicons for all buttons

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_6885c497b7dc832e9942f60fe1a44138